### PR TITLE
コメントも展開できるようにする

### DIFF
--- a/lib/esa_client.rb
+++ b/lib/esa_client.rb
@@ -62,14 +62,57 @@ class EsaClient
     return info
   end
 
+  def get_comment(comment_number)
+    # 古いキャッシュを消す
+    keys = @redis.keys("comment-*")
+    now = Time.now
+    keys.each do |key|
+      json = @redis.get(key)
+      cache = JSON.parse(json)
+      created_at = Time.parse(cache['created_at'])
+      diff = now - created_at
+
+      # 1時間以上前のログを消す
+      @redis.del(key) if diff > (60 * 60)
+    end
+
+    cache_json = @redis.get("comment-#{comment_number}")
+    unless cache_json.nil?
+      puts '[LOG] cache hit'
+      cache = JSON.parse(cache_json)
+      return cache['info']
+    end
+
+    comment = @esa_client.comment(comment_number).body
+    return {} if comment.nil?
+
+    title = comment['full_name']
+    title.insert(0, '[WIP] ') if comment['wip']
+    footer = generate_footer(comment)
+    text = comment['body_md'].lines.map{ |item| item.chomp }.join("\n")
+    info = {
+      title: 'コメント',
+      title_link: comment['url'],
+      author_name: comment['created_by']['screen_name'],
+      author_icon: comment['created_by']['icon'],
+      text: text,
+      color: '#3E8E89',
+      footer: footer,
+      ts: Time.parse(post['updated_at']).to_i
+    }
+
+    set_redis("comment-#{comment_number}", info)
+    return info
+  end
+
   private
-  def set_redis(post_number, info)
+  def set_redis(key, info)
     json = {
       created_at: Time.now,
       info: info
     }.to_json
 
-    @redis.set(post_number, json)
+    @redis.set(key, json)
   end
 
   def generate_footer(post)

--- a/main.rb
+++ b/main.rb
@@ -27,11 +27,18 @@ post '/' do
     unfurls = {}
     links.each do |link|
       url = link['url']
-      next unless url =~ /\Ahttps:\/\/#{ESA_TEAM_NAME}.esa.io\/posts\/(\d+).*\z/
-      post_number = $1
 
-      esa = EsaClient.new
-      attachment = esa.get(post_number)
+      if url =~ /\Ahttps:\/\/pixiv.esa.io\/posts\/\d+#comment-(\d+).*\z/
+        comment_number = $1
+        esa = EsaClient.new
+        attachment = esa.get_comment(comment_number)
+        unfurls[url] = attachment
+      elsif url =~ /\Ahttps:\/\/pixiv.esa.io\/posts\/(\d+).*\z/
+        post_number = $1
+        esa = EsaClient.new
+        attachment = esa.get_post(post_number)
+        unfurls[url] = attachment
+      end
 
       unfurls[url] = attachment
     end


### PR DESCRIPTION
- 記事へのコメントURLをSlackに貼った場合の挙動を変更

### Before
- 記事の内容が展開される

### After
- コメントの内容が展開される