### PR TITLE
環境変数を導入し、記事とコメントの出力行数を制御可能にした

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,6 +17,10 @@
     },
     "ESA_TEAM_NAME": {
       "description": "Esa team name of targeted for URL unfurling"
+    },
+    "ESA_OUTPUT_FORMAT": {
+      "description": "The format outputting by Kujaku. 'full' or 'title' (default: 'full')",
+      "required": false
     }
   },
   "image": "heroku/ruby",

--- a/app.json
+++ b/app.json
@@ -18,8 +18,12 @@
     "ESA_TEAM_NAME": {
       "description": "Esa team name of targeted for URL unfurling"
     },
-    "ESA_OUTPUT_FORMAT": {
-      "description": "The format outputting by Kujaku. 'full' or 'title' (default: 'full')",
+    "ESA_MAX_ARTICLE_LINES": {
+      "description": "Maximum number of lines of article text outputting by Kujaku. (default: 10)",
+      "required": false
+    },
+    "ESA_MAX_COMMENT_LINES": {
+      "description": "Maximum number of lines of comment text outputting by Kujaku. (default: 10)",
       "required": false
     }
   },

--- a/lib/esa_client.rb
+++ b/lib/esa_client.rb
@@ -6,7 +6,8 @@ require 'time'
 class EsaClient
   ESA_ACCESS_TOKEN = ENV['ESA_ACCESS_TOKEN']
   ESA_TEAM_NAME = ENV['ESA_TEAM_NAME']
-  ESA_OUTPUT_FORMAT = ENV.fetch('ESA_OUTPUT_FORMAT', 'full')
+  ESA_MAX_ARTICLE_LINES = ENV.fetch('ESA_MAX_ARTICLE_LINES', '10').to_i
+  ESA_MAX_COMMENT_LINES = ENV.fetch('ESA_MAX_COMMENT_LINES', '10').to_i
   REDIS_URL = ENV['REDISTOGO_URL']
 
   def initialize
@@ -50,7 +51,7 @@ class EsaClient
       title_link: post['url'],
       author_name: post['created_by']['screen_name'],
       author_icon: post['created_by']['icon'],
-      text: post_text(post),
+      text: article_text(post),
       color: '#3E8E89',
       footer: footer,
       ts: Time.parse(post['updated_at']).to_i
@@ -103,15 +104,12 @@ class EsaClient
   end
 
   private
-  def post_text(post)
-    return '' if ESA_OUTPUT_FORMAT == 'title'
-    # 素のままだと省略されても長いので10行までにする
-    post['body_md'].lines[0, 10].map{ |item| item.chomp }.join("\n")
+  def article_text(post)
+    post['body_md'].lines[0, ESA_MAX_ARTICLE_LINES].map{ |item| item.chomp }.join("\n")
   end
 
   def comment_text(comment)
-    return '' if ESA_OUTPUT_FORMAT == 'title'
-    comment['body_md'].lines.map{ |item| item.chomp }.join("\n")
+    comment['body_md'].lines[0, ESA_MAX_COMMENT_LINES].map{ |item| item.chomp }.join("\n")
   end
 
   def set_redis(key, info)


### PR DESCRIPTION
@FromAtom

便利なアプリをありがとうございます。

以下の環境変数を導入し、記事とコメントの出力行数を制御可能にしました。

* `ESA_MAX_ARTICLE_LINES`
* `ESA_MAX_COMMENT_LINES`

`ESA_MAX_ARTICLE_LINES` に 0 をセットする前と後の出力の変化です。

<img width="523" alt="ESA_MAX_ARTICLE_LINES をセットしない" src="https://user-images.githubusercontent.com/170014/106617235-c691e900-65b1-11eb-9871-aa57cb8cae01.png">

⬇️

<img width="450" alt="ESA_MAX_ARTICLE_LINES に 0 をセットする" src="https://user-images.githubusercontent.com/170014/106617279-d0b3e780-65b1-11eb-9e81-286335ce3782.png">

:warning: `ESA_MAX_COMMENT_LINES` を導入したことで、コメントの出力行数が 10 に変わった点は議論の余地がありそうです。
