### PR TITLE
コメントのタイトルに記事タイトルを入れた

### DIFF
--- a/lib/esa_client.rb
+++ b/lib/esa_client.rb
@@ -62,7 +62,7 @@ class EsaClient
     return info
   end
 
-  def get_comment(comment_number)
+  def get_comment(post_number, comment_number)
     # 古いキャッシュを消す
     keys = @redis.keys("comment-*")
     now = Time.now
@@ -83,6 +83,9 @@ class EsaClient
       return cache['info']
     end
 
+    post = @esa_client.post(post_number).body
+    post_title = post.nil? ? '？？？' : post['full_name']
+
     comment = @esa_client.comment(comment_number).body
     return {} if comment.nil?
 
@@ -91,7 +94,7 @@ class EsaClient
     footer = generate_footer(comment)
     text = comment['body_md'].lines.map{ |item| item.chomp }.join("\n")
     info = {
-      title: 'コメント',
+      title: "#{post_title} へのコメント",
       title_link: comment['url'],
       author_name: comment['created_by']['screen_name'],
       author_icon: comment['created_by']['icon'],

--- a/main.rb
+++ b/main.rb
@@ -28,10 +28,11 @@ post '/' do
     links.each do |link|
       url = link['url']
 
-      if url =~ /\Ahttps:\/\/#{ESA_TEAM_NAME}.esa.io\/posts\/\d+#comment-(\d+).*\z/
-        comment_number = $1
+      if url =~ /\Ahttps:\/\/#{ESA_TEAM_NAME}.esa.io\/posts\/(\d+)+#comment-(\d+).*\z/
+        post_number = $1
+        comment_number = $2
         esa = EsaClient.new
-        attachment = esa.get_comment(comment_number)
+        attachment = esa.get_comment(post_number, comment_number)
         unfurls[url] = attachment
       elsif url =~ /\Ahttps:\/\/#{ESA_TEAM_NAME}.esa.io\/posts\/(\d+).*\z/
         post_number = $1


### PR DESCRIPTION
今までは「コメント」固定でしたが、記事タイトルを含めるようにしました。

「コメント」

<img alt="before" src="https://user-images.githubusercontent.com/170014/106618195-8ed77100-65b2-11eb-8541-21ab300ac63b.png" width="450">

⬇️

「hoge/2021/02/03/今日の日記 へのコメント」

<img alt="After" src="https://user-images.githubusercontent.com/170014/106618377-bb8b8880-65b2-11eb-93bd-19030b3dffcf.png" width="363" >

API 2 回呼ぶので微妙ですが、コメントを共有することは少ないと思うので、問題ないような気がします。