### PR TITLE
Fix Procfile warning at Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rackup config.ru -p $PORT


### PR DESCRIPTION
ついでに直しました。https://devcenter.heroku.com/articles/ruby-support#rack-applications-process-types を参考にしました。

```
$ git push heroku master
(snip)
remote: ###### WARNING:                                                                                                                                                        
remote:                      
remote:        No Procfile detected, using the default web server.                     
remote:        We recommend explicitly declaring how to boot your server process via a Procfile.
remote:        https://devcenter.heroku.com/articles/ruby-default-web-server           
```

