### PR TITLE
古いキャッシュの削除は Redis にお任せする

### DIFF
--- a/lib/esa_client.rb
+++ b/lib/esa_client.rb
@@ -19,19 +19,6 @@ class EsaClient
   end
 
   def get_post(post_number)
-    # 古いキャッシュを消す
-    keys = @redis.keys("*")
-    now = Time.now
-    keys.each do |key|
-      json = @redis.get(key)
-      cache = JSON.parse(json)
-      created_at = Time.parse(cache['created_at'])
-      diff = now - created_at
-
-      # 1時間以上前のログを消す
-      @redis.del(key) if diff > (60 * 60)
-    end
-
     cache_json = @redis.get(post_number)
     unless cache_json.nil?
       puts '[LOG] cache hit'
@@ -62,19 +49,6 @@ class EsaClient
   end
 
   def get_comment(comment_number)
-    # 古いキャッシュを消す
-    keys = @redis.keys("comment-*")
-    now = Time.now
-    keys.each do |key|
-      json = @redis.get(key)
-      cache = JSON.parse(json)
-      created_at = Time.parse(cache['created_at'])
-      diff = now - created_at
-
-      # 1時間以上前のログを消す
-      @redis.del(key) if diff > (60 * 60)
-    end
-
     cache_json = @redis.get("comment-#{comment_number}")
     unless cache_json.nil?
       puts '[LOG] cache hit'
@@ -114,11 +88,10 @@ class EsaClient
 
   def set_redis(key, info)
     json = {
-      created_at: Time.now,
       info: info
     }.to_json
 
-    @redis.set(key, json)
+    @redis.set(key, json, ex: 60 * 60)
   end
 
   def generate_footer(post)

--- a/lib/esa_client.rb
+++ b/lib/esa_client.rb
@@ -9,6 +9,7 @@ class EsaClient
   ESA_MAX_ARTICLE_LINES = ENV.fetch('ESA_MAX_ARTICLE_LINES', '10').to_i
   ESA_MAX_COMMENT_LINES = ENV.fetch('ESA_MAX_COMMENT_LINES', '10').to_i
   REDIS_URL = ENV['REDISTOGO_URL']
+  REDIS_TTL = 60 * 60 # 1時間
 
   def initialize
     @esa_client = Esa::Client.new(
@@ -90,7 +91,7 @@ class EsaClient
     # ttl導入前のkeyが残り続けることを避ける
     @redis.keys.each do |key|
       if @redis.ttl(key) == -1
-        @redis.expire(key, 60 * 60)
+        @redis.expire(key, REDIS_TTL)
       end
     end
 
@@ -102,7 +103,7 @@ class EsaClient
       info: info
     }.to_json
 
-    @redis.set(key, json, ex: 60 * 60)
+    @redis.set(key, json, ex: REDIS_TTL)
   end
 
   def generate_footer(post)

--- a/lib/esa_client.rb
+++ b/lib/esa_client.rb
@@ -19,7 +19,7 @@ class EsaClient
   end
 
   def get_post(post_number)
-    cache_json = @redis.get(post_number)
+    cache_json = get_redis(post_number)
     unless cache_json.nil?
       puts '[LOG] cache hit'
       cache = JSON.parse(cache_json)
@@ -49,7 +49,7 @@ class EsaClient
   end
 
   def get_comment(comment_number)
-    cache_json = @redis.get("comment-#{comment_number}")
+    cache_json = get_redis("comment-#{comment_number}")
     unless cache_json.nil?
       puts '[LOG] cache hit'
       cache = JSON.parse(cache_json)
@@ -84,6 +84,17 @@ class EsaClient
 
   def comment_text(comment)
     comment['body_md'].lines[0, ESA_MAX_COMMENT_LINES].map{ |item| item.chomp }.join("\n")
+  end
+
+  def get_redis(key)
+    # ttl導入前のkeyが残り続けることを避ける
+    @redis.keys.each do |key|
+      if @redis.ttl(key) == -1
+        @redis.expire(key, 60 * 60)
+      end
+    end
+
+    @redis.get(key)
   end
 
   def set_redis(key, info)


### PR DESCRIPTION
コードを読んでて気になっていたので、Redis の Expire を使ってリファクタリングしてみました。
すでに存在する key には TTL が設定されておらず、永久に残り続けてしまうため、 24cdd172b7a485db4740cdd68099488a6a1ab1c0 で救っています。
いかがでしょうか。

公式ドキュメント:

* [Redis#keys](https://www.rubydoc.info/github/redis/redis-rb/Redis:keys)
* [Redis#ttl](https://www.rubydoc.info/github/redis/redis-rb/Redis:ttl)
* [Redis#expire](https://www.rubydoc.info/github/redis/redis-rb/Redis:expire)
* [Redis#set](https://www.rubydoc.info/github/redis/redis-rb/Redis:set)
