### PR TITLE
テキストに含まれる &#35; と &#47; をそれぞれ # と / に置換する

### DIFF
--- a/lib/esa_client.rb
+++ b/lib/esa_client.rb
@@ -35,7 +35,7 @@ class EsaClient
     footer = generate_footer(post)
 
     info = {
-      title: title,
+      title: unescape(title),
       title_link: post['url'],
       author_name: post['created_by']['screen_name'],
       author_icon: post['created_by']['icon'],
@@ -80,11 +80,15 @@ class EsaClient
 
   private
   def article_text(post)
-    post['body_md'].lines[0, ESA_MAX_ARTICLE_LINES].map{ |item| item.chomp }.join("\n")
+    unescape(post['body_md'].lines[0, ESA_MAX_ARTICLE_LINES].map{ |item| item.chomp }.join("\n"))
   end
 
   def comment_text(comment)
-    comment['body_md'].lines[0, ESA_MAX_COMMENT_LINES].map{ |item| item.chomp }.join("\n")
+    unescape(comment['body_md'].lines[0, ESA_MAX_COMMENT_LINES].map{ |item| item.chomp }.join("\n"))
+  end
+
+  def unescape(str)
+    str.gsub('&#35;', '#').gsub('&#47;', '/')
   end
 
   def get_redis(key)


### PR DESCRIPTION
テキストに含まれる `&#35;` と `&#47;` をそれぞれ `#` と `/` に置換し、可読性を上げました。ここで言うテキストとは、タイトル、本文、コメントの３つです。

<img alt="Before" src="https://user-images.githubusercontent.com/170014/111329060-29e36080-86b2-11eb-9782-047b825607f6.png" width="500">

:arrow_down:

<img alt="After" src="https://user-images.githubusercontent.com/170014/111329084-3071d800-86b2-11eb-9e4d-6f38f2f67f50.png" width="500">

`&#35;` と `&#47;` に限定したのは、esa ドキュメントではそれ以外に言及していないためです。

:link: [dev/esa/api/v1 \#noexpand \- docs\.esa\.io](https://docs.esa.io/posts/102)

> タイトル自体に`#`を含めたい場合は`&#35;`, `/`を含めたい場合は`&#47;`へそれぞれ置換処理をお願いします。

実際には `&#36;` => `$`, `&#37;` => `%` のようにも置換されますが、難読化を救う実装までしなくて良いと思ったので、一旦ミニマムにしました。
